### PR TITLE
Include CSS from @dahlia/styles in Storybook

### DIFF
--- a/shared/ui-components/.storybook/config.ts
+++ b/shared/ui-components/.storybook/config.ts
@@ -1,4 +1,5 @@
 import { configure } from "@storybook/react"
+import "@dahlia/styles/src/index.scss"
 
 // automatically import all files ending in *.stories.tsx
 const req = require.context("../src", true, /stories\.tsx$/)

--- a/shared/ui-components/.storybook/webpack.config.js
+++ b/shared/ui-components/.storybook/webpack.config.js
@@ -10,7 +10,21 @@ module.exports = ({ config }) => {
         loader: require.resolve("react-docgen-typescript-loader")
       }
     ]
-  });
-  config.resolve.extensions.push(".ts", ".tsx");
-  return config;
-};
+  })
+  config.module.rules.push({
+    test: /\.scss$/,
+    use: [
+      "style-loader",
+      {
+        loader: "postcss-loader",
+        options: {
+          ident: "postcss",
+          plugins: [require("tailwindcss"), require("autoprefixer")]
+        }
+      },
+      "sass-loader"
+    ]
+  })
+  config.resolve.extensions.push(".ts", ".tsx")
+  return config
+}

--- a/shared/ui-components/package.json
+++ b/shared/ui-components/package.json
@@ -31,11 +31,16 @@
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.0",
     "jest": "^24.8.0",
+    "node-sass": "^4.12.0",
+    "postcss-loader": "^3.0.0",
     "react-docgen-typescript-loader": "^3.1.0",
+    "sass-loader": "^7.3.1",
+    "style-loader": "^1.0.0",
     "typescript": "^3.5.3",
     "webpack": "^4.39.1"
   },
   "dependencies": {
+    "@dahlia/styles": "*",
     "@types/node": "^12.7.1",
     "@types/react-dom": "^16.8.5",
     "react": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3871,6 +3871,15 @@ clone-deep@^0.3.0:
     kind-of "^3.2.2"
     shallow-clone "^0.1.2"
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -11222,6 +11231,17 @@ sass-loader@6.0.6:
     lodash.tail "^4.1.1"
     pify "^3.0.0"
 
+sass-loader@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
+  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
+  dependencies:
+    clone-deep "^4.0.1"
+    loader-utils "^1.0.1"
+    neo-async "^2.5.0"
+    pify "^4.0.1"
+    semver "^6.3.0"
+
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -11242,6 +11262,14 @@ schema-utils@^1.0.0:
   dependencies:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
+    ajv-keywords "^3.1.0"
+
+schema-utils@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.1.0.tgz#940363b6b1ec407800a22951bdcc23363c039393"
+  integrity sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==
+  dependencies:
+    ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
 scss-tokenizer@^0.2.3:
@@ -11393,6 +11421,13 @@ shallow-clone@^0.1.2:
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
+
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
 
 shallow-equal@^1.1.0:
   version "1.2.0"
@@ -11947,6 +11982,14 @@ style-loader@^0.23.1:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
+
+style-loader@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.0.0.tgz#1d5296f9165e8e2c85d24eee0b7caf9ec8ca1f82"
+  integrity sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==
+  dependencies:
+    loader-utils "^1.2.3"
+    schema-utils "^2.0.1"
 
 style-to-object@0.2.3, style-to-object@^0.2.1:
   version "0.2.3"


### PR DESCRIPTION
Pulls `index.scss` from `@dahlia/styles` into Storybook so our stories will be styled.

Had to do the stuff in the `fix-linting-errors` branch before I could run Storybook and do commits, so this branch is branched off that branch and this PR is based on that branch to show an appropriate diff. Can rebase as needed before merging to master.